### PR TITLE
Update aws-sam-translator pin and use Grayskull order

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,4 +1,6 @@
-bot: {automerge: true}
+bot:
+  automerge: true
+  inspection: update-grayskull
 conda_forge_output_validation: true
 provider: {linux_aarch64: emulated, linux_ppc64le: emulated, win: azure}
 github:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,18 +19,18 @@ build:
 
 requirements:
   host:
-    - python >=3.7
+    - python >=3.7,<4.0
     - pip
   run:
-    - python >=3.7
-    - aws-sam-translator >=1.70.0
-    - jschema-to-python ~=1.2.3
-    - jsonpatch
-    - jsonschema <4.18,>=3.0
-    - junit-xml ~=1.9
-    - networkx ~=2.4,<4
+    - python >=3.7,<4.0
     - pyyaml >5.4
-    - sarif-om ~=1.0.4
+    - aws-sam-translator >=1.71.0
+    - jsonpatch
+    - jsonschema >=3.0,<4.18
+    - networkx >=2.4,<4
+    - junit-xml >=1.9,<2.dev0
+    - jschema-to-python >=1.2.3,<1.3.dev0
+    - sarif-om >=1.0.4,<1.1.dev0
     - sympy >=1.0.0
     - regex
 


### PR DESCRIPTION
The incorrect aws-sam-translator pins have been giving me a lot of grief, leading to lots of invalid environments.

Fixes the current pins and adds update-grayskull bot inspection.